### PR TITLE
Change the environment variable pointing to in deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,13 +42,13 @@ jobs:
       run: dotnet test --no-build --configuration Release --verbosity normal
     - name: Pack
       if: startsWith(github.ref, 'refs/tags/v')
-      run: dotnet pack -p:PackageVersion=${{ env.nugetVersion }} --configuration Release -o ${{env.DOTNET_ROOT}}/TestTools.ConsolePack --no-build 
+      run: dotnet pack -p:PackageVersion=${{ env.nugetVersion }} --configuration Release -o ${{github.workspace}}/TestTools.ConsolePack --no-build 
     - name: Upload Artifacts
       if: startsWith(github.ref, 'refs/tags/v')
       uses: actions/upload-artifact@v3
       with:
         name: NuGet
-        path: ${{env.DOTNET_ROOT}}/TestTools.ConsolePack
+        path: ${{github.workspace}}/TestTools.ConsolePack
       
   deploy:
     if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
github.workspace should be more static than env.DOTNET_ROOT